### PR TITLE
Avoid crash when no app can open an external link

### DIFF
--- a/src/main/java/org/billthefarmer/notes/Notes.java
+++ b/src/main/java/org/billthefarmer/notes/Notes.java
@@ -971,7 +971,14 @@ public class Notes extends Activity
                 if (external || MAILTO.equalsIgnoreCase(uri.getScheme()))
                 {
                     Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                    startActivity(intent);
+                    try
+                    {
+                        startActivity(intent);
+                    }
+                    catch (Exception e)
+                    {
+                        showToast(R.string.no_app);
+                    }
                     return true;
                 }
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
   <string name="access">Access all files</string>
 
   <string name="ok">OK</string>
+  <string name="no_app">No application found to open this link</string>
   <string name="reload">Reload</string>
   <string name="overwrite">Overwrite</string>
   <string name="discard">Discard</string>


### PR DESCRIPTION
`Notes` opens external and `mailto:` links from the markdown view with `startActivity`. On a device with no matching app this throws `ActivityNotFoundException` and crashes the app.

This wraps the launch in a try/catch and shows a short message when nothing can open the link. Loading local notes and asset links is unchanged.

Closes #67
